### PR TITLE
Please remove Inmoment.com domains as already done on Adaway

### DIFF
--- a/Rules/AdAway.txt
+++ b/Rules/AdAway.txt
@@ -6192,11 +6192,6 @@
 # [inmoji.com]
 127.0.0.1 api.inmoji.com
 
-# [inmoment.com]
-127.0.0.1 dispawsusva.inmoment.com
-127.0.0.1 intercept.inmoment.com
-127.0.0.1 intercept-client.inmoment.com
-
 # [inner-active.mobi]
 127.0.0.1 inner-active.mobi
 127.0.0.1 ad-tag.inner-active.mobi


### PR DESCRIPTION
Please merge this request to be consistent with Adaway. These domains were removed earlier today from the Adaway list. As you can see by the comments of the contributor who committed the merge, Inmoment.com did not need to be on the list.

AdAway/adaway.github.io@8fac381

InMoment (www.inmoment.com) is a feedback and research company with corporate offices in Salt Lake City, Utah. We have been mistakenly added to the Adaway list. We do not serve any ads. We don't collect any personal information, but we do gather some browser info to help us combat fraud by end users (maybe that is a tripping wire). Some of our programs offer an incentive for providing feedback, like a coupon, free drink, etc which have been abused in the past. We recently have a number of client and customer complaints that our surveys are not rendering properly and our investigation led us to the addition of our domains on Adaway and your list. We kindly request we be removed from this list. Thank you kindly for your hard work and support to privacy.